### PR TITLE
Bump asset-exporter version to Fix Compilation to Native Device

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"react-native-heic-converter": "1.3.1",
 		"react-native-image-picker": "4.7.3",
 		"react-native-image-resizer": "1.4.5",
-		"react-native-ios-asset-exporter": "^0.1.5",
+		"react-native-ios-asset-exporter": "^0.1.6",
 		"react-native-logs": "5.0.1",
 		"react-native-mmkv": "2.0.1",
 		"react-native-permissions": "3.3.0",


### PR DESCRIPTION
Interesting issue with package deployment version even when deployment is set to the correct version.

Fix: Added @available to the whole class.