### PR TITLE
Fix 2 File Provider Bugs

### DIFF
--- a/ios/FileProviderExt/FileProviderExtension.swift
+++ b/ios/FileProviderExt/FileProviderExtension.swift
@@ -41,8 +41,8 @@ class FileProviderExtension: NSFileProviderExtension {
     
     if (identifier.rawValue == "root" || identifier == NSFileProviderItemIdentifier.rootContainer || identifier.rawValue == rootFolderUUID || identifier.rawValue == NSFileProviderItemIdentifier.rootContainer.rawValue) {
       return FileProviderItem(
-        identifier: NSFileProviderItemIdentifier.rootContainer,
-        parentIdentifier: NSFileProviderItemIdentifier.rootContainer,
+        identifier: NSFileProviderItemIdentifier(rootFolderUUID),
+        parentIdentifier: NSFileProviderItemIdentifier(rootFolderUUID),
         item: Item(
           uuid: rootFolderUUID,
           parent: "root",
@@ -119,7 +119,7 @@ class FileProviderExtension: NSFileProviderExtension {
     do {
       _ = try await FileProviderUtils.shared.downloadFile(uuid: itemJSON.uuid, url: url.path, maxChunks: itemJSON.chunks)
       
-      FileProviderUtils.shared.signalEnumeratorForIdentifier(for: identifier)
+      FileProviderUtils.shared.signalEnumeratorForIdentifier(for: NSFileProviderItemIdentifier(rawValue: itemJSON.parent))
     } catch {
       print("[startProvidingItem] error:", error)
       


### PR DESCRIPTION
Changing line 122 notifies the parent that the local file has been accessed

Changing line 44 and 45 tell the system that the uuid of the root folders. I think this fixes the bug of user actions causing a return to the root folder because the system wasn't able to identify the proper root folder with only the predefined .rootContainer flag.