### PR TITLE
iOS 16 and below compatibility

### DIFF
--- a/ios/FileProviderExt/FileProviderUtils.swift
+++ b/ios/FileProviderExt/FileProviderUtils.swift
@@ -634,7 +634,7 @@ class FileProviderUtils {
   func encryptAndUploadChunk (url: String, chunkSize: Int, uuid: String, index: Int, uploadKey: String, parent: String, key: String) async throws -> (region: String, bucket: String) {
     let fileURL = try self.getTempPath().appendingPathComponent(UUID().uuidString.lowercased() + "." + uuid + "." + String(index), isDirectory: false)
     
-    guard let inputURL = URL(string: url) else {
+    guard let inputURL = URL(string: url.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? url) else {
       throw NSError(domain: "encryptAndUploadChunk", code: 1, userInfo: nil)
     }
     
@@ -675,7 +675,7 @@ class FileProviderUtils {
     
     let stat = try FileManager.default.attributesOfItem(atPath: url)
     
-    guard let fileSize = stat[.size] as? Int, let fileURL = URL(string: url), let lastModified = stat[.modificationDate] as? Date else {
+    guard let fileSize = stat[.size] as? Int, let fileURL = URL(string: url.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? url), let lastModified = stat[.modificationDate] as? Date else {
       throw NSFileProviderError(.noSuchItem)
     }
     
@@ -1261,7 +1261,7 @@ class FileProviderUtils {
       return (didDownload: false, url: "")
     }
     
-    guard let itemJSON = self.getItemFromUUID(uuid: uuid), let destinationURL = URL(string: url) else {
+    guard let itemJSON = self.getItemFromUUID(uuid: uuid), let destinationURL = URL(string: url.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? url) else {
       throw NSFileProviderError(.noSuchItem)
     }
     


### PR DESCRIPTION
For apps linked on or after iOS 17 and aligned OS versions, [URL](https://developer.apple.com/documentation/foundation/url) parsing has updated from the obsolete RFC 1738/1808 parsing to the same [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) parsing as [URLComponents](https://developer.apple.com/documentation/foundation/urlcomponents). This unifies the parsing behaviors of the URL and URLComponents APIs. Now, URL automatically percent- and IDNA-encodes invalid characters to help create a valid URL.

-- https://developer.apple.com/documentation/foundation/url/3126806-init

Fix for FilenCloudDienste/filen-mobile#346